### PR TITLE
Add '--without-heartbeat' to worker args

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: python manage.py migrate
 web: gunicorn commons_api.wsgi:application
-worker: celery -A commons_api worker
+worker: celery -A commons_api worker --without-heartbeat


### PR DESCRIPTION
This will apparently drastically reduce the number of messages sent to/from the
CloudAMQP instance when run on Heroku, meaning we're less likely to hit usage
limits.

See https://www.cloudamqp.com/docs/celery.html for context.