### PR TITLE
Add a GeoJSON renderer, and spatial API endpoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
+dist: xenial
 language: python
-services:
-  - postgresql
+before_install:
+  - sudo add-apt-repository ppa:ubuntugis/ppa -y
+  - sudo apt-get update -q
+  - sudo apt-get install postgis postgresql-10 postgresql-10-postgis-2.4 postgresql-10-postgis-2.4-scripts postgresql-client-10 postgresql-contrib-10 python-gdal -y
+  - sudo systemctl start postgresql
 addons:
   postgresql: "10"
-  apt:
-    packages:
-    - postgis
-    - postgresql-10
-    - postgresql-10-postgis-2.4
-    - postgresql-10-postgis-2.4-scripts
-    - postgresql-client-10
-    - postgresql-contrib-10
-    - python-gdal
 python:
   - "3.6"
 install:
@@ -20,7 +15,7 @@ install:
 env:
   global:
     - DJANGO_SETTINGS_MODULE=commons_api.tests.settings DJANGO_ALLOWED_HOSTS=localhost
-    - PGPORT=5433
+    - PGPORT=5432
 script: PYTHONPATH=. coverage run --source=. `which django-admin.py` test
 after_success:
   - codecov

--- a/commons_api/settings.py
+++ b/commons_api/settings.py
@@ -108,6 +108,9 @@ CELERY_TASK_ROUTES = {
 
 CELERY_RESULT_BACKEND = 'django-db'
 
+BOUNDARIES_SIMPLE_SHAPE_TOLERANCE = os.environ.get(
+    'BOUNDARIES_SIMPLE_SHAPE_TOLERANCE', 0.001)
+
 if 'DYNO' in os.environ:
     # django_heroku uses dj_database_url, so tell it we're using PostGIS
     os.environ['DATABASE_URL'] = re.sub('^postgres:', 'postgis:', os.environ['DATABASE_URL'])

--- a/commons_api/settings.py
+++ b/commons_api/settings.py
@@ -30,6 +30,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.postgres',
     'django.contrib.humanize',
+    'django_filters',
     'rest_framework',
     'django_celery_results',
     'commons_api',
@@ -89,7 +90,8 @@ ENABLE_MODERATION = bool(os.environ.get('ENABLE_MODERATION'))
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'PAGE_SIZE': 1000
+    'PAGE_SIZE': 1000,
+    'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',)
 }
 
 DEMOCRATIC_COMMONS_GITHUB_USER = os.environ.get('DEMOCRATIC_COMMONS_GITHUB_USER', 'everypolitician')

--- a/commons_api/settings.py
+++ b/commons_api/settings.py
@@ -90,7 +90,7 @@ ENABLE_MODERATION = bool(os.environ.get('ENABLE_MODERATION'))
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'PAGE_SIZE': 1000,
+    'PAGE_SIZE': int(os.environ.get('REST_FRAMEWORK_PAGE_SIZE') or 1000),
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',)
 }
 

--- a/commons_api/templates/base.html
+++ b/commons_api/templates/base.html
@@ -32,6 +32,7 @@
             <a class="pure-menu-heading" href="/">Democratic Commons <em>demo</em></a>
 <ul class="pure-menu-list">
         <li class="pure-menu-item"><a href="{% url "wikidata:country-list" %}" class="pure-menu-link">Countries</a></li>
+        <li class="pure-menu-item"><a href="{% url "wikidata:api:api-root" %}" class="pure-menu-link">API</a></li>
      </ul>
         </div>
     </div>

--- a/commons_api/wikidata/api.py
+++ b/commons_api/wikidata/api.py
@@ -5,4 +5,5 @@ from . import viewsets
 router = DefaultRouter()
 
 router.register('country', viewsets.CountryViewSet)
+router.register('electoral-district', viewsets.ElectoralDistrictViewSet)
 router.register('legislative-membership', viewsets.LegislativeMembershipViewSet)

--- a/commons_api/wikidata/api.py
+++ b/commons_api/wikidata/api.py
@@ -4,4 +4,5 @@ from . import viewsets
 
 router = DefaultRouter()
 
+router.register('country', viewsets.CountryViewSet)
 router.register('legislative-membership', viewsets.LegislativeMembershipViewSet)

--- a/commons_api/wikidata/serializers.py
+++ b/commons_api/wikidata/serializers.py
@@ -46,7 +46,7 @@ class PersonSerializer(ModelSerializer):
 class ElectoralDistrictSerializer(SpatialSerializer):
     class Meta:
         model = models.ElectoralDistrict
-        fields = ('id', 'labels')
+        fields = ('id', 'labels', 'legislative_house')
 
 
 class AdministrativeAreaSerializer(ModelSerializer):

--- a/commons_api/wikidata/serializers.py
+++ b/commons_api/wikidata/serializers.py
@@ -31,6 +31,12 @@ class SpatialSerializer(ModelSerializer):
         return data
 
 
+class CountrySerializer(SpatialSerializer):
+    class Meta:
+        model = models.Country
+        fields = ('id', 'labels', 'flag_image', 'population', 'iso_3166_1_code', 'wikipedia_articles')
+
+
 class PersonSerializer(ModelSerializer):
     class Meta:
         model = models.Person

--- a/commons_api/wikidata/serializers.py
+++ b/commons_api/wikidata/serializers.py
@@ -1,6 +1,34 @@
+import json
+
 from rest_framework.serializers import ModelSerializer
 
+from boundaries.views import BoundaryListView
 from . import models
+
+
+class SpatialSerializer(ModelSerializer):
+    default_geo_field = 'simple_shape'
+    allowed_geo_fields = BoundaryListView.allowed_geo_fields
+
+    @property
+    def geo_field_name(self):
+        geo_field = self.context['request'].GET.get('geometry',
+                                                    self.default_geo_field)
+        if geo_field in self.allowed_geo_fields:
+            return geo_field
+
+    @property
+    def should_expose_geometry(self):
+        return self.context['format'] == 'geojson' or 'geometry' in self.context['request'].GET
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        if self.should_expose_geometry and self.geo_field_name:
+            if instance.boundary_id:
+                data['geometry'] = json.loads(getattr(instance.boundary, self.geo_field_name).geojson)
+            else:
+                data['geometry'] = None
+        return data
 
 
 class PersonSerializer(ModelSerializer):
@@ -9,7 +37,7 @@ class PersonSerializer(ModelSerializer):
         fields = ('id', 'labels', 'facebook_id', 'twitter_id')
 
 
-class ElectoralDistrictSerializer(ModelSerializer):
+class ElectoralDistrictSerializer(SpatialSerializer):
     class Meta:
         model = models.ElectoralDistrict
         fields = ('id', 'labels')

--- a/commons_api/wikidata/tests/__init__.py
+++ b/commons_api/wikidata/tests/__init__.py
@@ -1,2 +1,3 @@
+from .geojson import *
 from .moderation import *
 from .serializers import *

--- a/commons_api/wikidata/tests/__init__.py
+++ b/commons_api/wikidata/tests/__init__.py
@@ -1,1 +1,2 @@
 from .moderation import *
+from .serializers import *

--- a/commons_api/wikidata/tests/geojson.py
+++ b/commons_api/wikidata/tests/geojson.py
@@ -1,0 +1,50 @@
+import json
+
+from django.contrib.gis.gdal import DataSource
+from django.contrib.gis.geos import Point
+from django.test import TestCase
+
+from .. import renderers
+
+
+class GeoJSONRendererTestCase(TestCase):
+    def setUp(self):
+        self.renderer = renderers.GeoJSONRenderer()
+        self.data_gb = {
+            "id": "Q145",
+            "labels": {
+                "en": "United Kingdom"
+            },
+            "flag_image": None,
+            "population": 65102385,
+            "iso_3166_1_code": "GB",
+            "wikipedia_articles": {},
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    -2.882623571004757,
+                    54.1551889188512
+                ]
+            }
+        }
+
+    def testRendersCountry(self):
+        rendered_data = self.renderer.render(self.data_gb, None, None).decode()
+        data_source = DataSource(rendered_data)
+        feature = data_source[0][0]
+        # Check the geometry round-tripped
+        self.assertEqual(self.data_gb['geometry'], json.loads(feature.geom.geojson))
+        # There should be fields for everything but 'geometry'
+        self.assertEqual(set(self.data_gb) - {'geometry'},
+                         set(feature.fields))
+        self.assertEqual(self.data_gb['id'], str(feature['id']))
+        self.assertEqual(self.data_gb['labels'], json.loads(str(feature['labels'])))
+
+    def testRendersList(self):
+        data = {
+            'results': [self.data_gb, self.data_gb],
+        }
+        rendered_data = self.renderer.render(data, None, None).decode()
+        data_source = DataSource(rendered_data)
+        # There are two features in this feature collection
+        self.assertEqual(2, len(data_source[0]))

--- a/commons_api/wikidata/tests/serializers.py
+++ b/commons_api/wikidata/tests/serializers.py
@@ -1,0 +1,79 @@
+import datetime
+import json
+
+from django.contrib.gis.gdal import OGRGeometry, DataSource
+
+from boundaries.models import Feature, BoundarySet, Definition
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from .. import models, serializers
+
+
+class SpatialSerializerTestCase(TestCase):
+    def setUp(self):
+        self.serializer_class = serializers.CountrySerializer
+        self.country = models.Country(id='Q145')
+        self.definition = Definition({'name_func': lambda feature: 'name',
+                                      'id_func': lambda feature: 'id',
+                                      'name': 'test-set'})
+        self.boundary_set = BoundarySet.objects.create(slug='test-set',
+                                                       last_updated=datetime.datetime.now())
+        self.feature = DataSource(json.dumps({
+            'type': 'Feature',
+            'geometry': {
+                'type': 'Polygon',
+                'coordinates': [
+                    [
+                        [30, 10], [40, 40], [20, 40], [10, 20], [30, 10],
+                    ],
+                ],
+            },
+        }))[0][0]
+        self.boundary = Feature(self.feature,
+                                boundary_set=self.boundary_set,
+                                definition=self.definition).create_boundary()
+        self.request_factory = APIRequestFactory()
+
+    def testWithoutGeometry(self):
+        serializer_context = {'format': 'json',
+                              'request': self.request_factory.get(path='/api/country/Q145')}
+        serializer = self.serializer_class(instance=self.country, context=serializer_context)
+        self.assertNotIn('geometry', serializer.data)
+
+    def testWithGeoJSONFormatNoGeometry(self):
+        serializer_context = {'format': 'geojson',
+                              'request': self.request_factory.get(path='/api/country/Q145')}
+        serializer = self.serializer_class(instance=self.country, context=serializer_context)
+        self.assertEqual(None, serializer.data['geometry'])
+
+    def testWithGeometryParameterNoGeometry(self):
+        serializer_context = {'format': 'json',
+                              'request': self.request_factory.get(path='/api/country/Q145',
+                                                                  data={'geometry': 'centroid'})}
+        serializer = self.serializer_class(instance=self.country, context=serializer_context)
+        self.assertEqual(None, serializer.data['geometry'])
+
+    def testWithCentroidGeometryParameterAndGeometry(self):
+        self.country.boundary_id = self.boundary.id
+        serializer_context = {'format': 'json',
+                              'request': self.request_factory.get(path='/api/country/Q145',
+                                                                  data={'geometry': 'centroid'})}
+        serializer = self.serializer_class(instance=self.country, context=serializer_context)
+        self.assertEqual(json.loads(self.feature.geom.centroid.geojson), serializer.data['geometry'])
+
+    def testWithShapeGeometryParameterAndGeometry(self):
+        self.country.boundary_id = self.boundary.id
+        serializer_context = {'format': 'json',
+                              'request': self.request_factory.get(path='/api/country/Q145',
+                                                                  data={'geometry': 'shape'})}
+        serializer = self.serializer_class(instance=self.country, context=serializer_context)
+        self.assertIn('coordinates', serializer.data['geometry'])
+
+    def testWithUnknownGeometryParameterAndGeometry(self):
+        self.country.boundary_id = self.boundary.id
+        serializer_context = {'format': 'json',
+                              'request': self.request_factory.get(path='/api/country/Q145',
+                                                                  data={'geometry': 'cake'})}
+        serializer = self.serializer_class(instance=self.country, context=serializer_context)
+        self.assertNotIn('geometry', serializer.data)

--- a/commons_api/wikidata/urls.py
+++ b/commons_api/wikidata/urls.py
@@ -38,5 +38,5 @@ urlpatterns = (
          views.ModerationItemDetailView.as_view(),
          name='moderationitem-detail'),
 
-    path('api/', include(api.router.get_urls()), name='api'),
+    path('api/', include((api.router.get_urls(), 'api'), 'api')),
 )

--- a/commons_api/wikidata/viewsets.py
+++ b/commons_api/wikidata/viewsets.py
@@ -4,6 +4,16 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 from . import models, renderers, serializers
 
 
+class CountryViewSet(ReadOnlyModelViewSet):
+    queryset = models.Country.objects.all().select_related('boundary')
+    serializer_class = serializers.CountrySerializer
+    renderer_classes = (
+        BrowsableAPIRenderer,
+        JSONRenderer,
+        renderers.GeoJSONRenderer,
+    )
+
+
 class LegislativeMembershipViewSet(ReadOnlyModelViewSet):
     queryset = models.LegislativeMembership.objects.filter(legislative_house_id='Q11005')
     serializer_class = serializers.LegislativeMembershipSerializer

--- a/commons_api/wikidata/viewsets.py
+++ b/commons_api/wikidata/viewsets.py
@@ -1,3 +1,4 @@
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
@@ -14,6 +15,20 @@ class CountryViewSet(ReadOnlyModelViewSet):
     )
 
 
+class ElectoralDistrictViewSet(ReadOnlyModelViewSet):
+    queryset = models.ElectoralDistrict.objects.all()
+    serializer_class = serializers.ElectoralDistrictSerializer
+    filter_fields = ('legislative_house',)
+    filter_backends = (
+        DjangoFilterBackend,
+    )
+    renderer_classes = (
+        BrowsableAPIRenderer,
+        JSONRenderer,
+        renderers.GeoJSONRenderer,
+    )
+
+
 class LegislativeMembershipViewSet(ReadOnlyModelViewSet):
     queryset = models.LegislativeMembership.objects.filter(legislative_house_id='Q11005')
     serializer_class = serializers.LegislativeMembershipSerializer
@@ -22,3 +37,4 @@ class LegislativeMembershipViewSet(ReadOnlyModelViewSet):
         JSONRenderer,
         renderers.PopoloJSONRenderer,
     )
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 celery
 Django
 django-dirtyfields
+django-filter
 django-heroku
 django-reversion
 djangorestframework


### PR DESCRIPTION
This adds everything to support a GeoJSON renderer, and `CountryViewSet` and `ElectoralDistrictViewset` API endpoints.

Example URLs:

* https://democratic-commons-demo-pr-32.herokuapp.com/api/country/?geometry=simple_shape (or `=centroid` or `=shape` (which would be huge; don't do this)
* https://democratic-commons-demo-pr-32.herokuapp.com/api/country/?format=geojson&geometry=simple_shape
* https://democratic-commons-demo-pr-32.herokuapp.com/api/electoral-district/?legislative_house=Q11005&geometry=centroid

So passing a `geometry` parameter to any API serializer that subclasses `SpatialSerializer` will cause it to add `geometry` attributes to the JSON objects it spits out. The `format=api` and `format=json` renderers will give you human- and computer-readable JSON views. `format=geojson` for any appropriate API viewset will give you real GeoJSON that you can e.g. load into QGIS. The attributes from the original JSON are then exposed in the GeoJSON Feature `properties` object.

This doesn't add links to the human exploratory pages yet, which I'll put in a separate PR.
