### PR TITLE
Include items in the country list if they are a country subclass

### DIFF
--- a/commons_api/wikidata/templates/wikidata/query/country_list.rq
+++ b/commons_api/wikidata/templates/wikidata/query/country_list.rq
@@ -1,8 +1,8 @@
 # Adapted from https://github.com/everypolitician/legislative-explorer/blob/master/lib/query/country_list.rb
 
-SELECT ?item ?itemLabel ?itemCode WHERE {
+SELECT DISTINCT ?item ?itemLabel ?itemCode WHERE {
   ?item p:P31 ?instanceOfStatement .
-  ?instanceOfStatement ps:P31 wd:Q6256 .
+  ?instanceOfStatement ps:P31/wdt:P279* wd:Q6256 .
   MINUS { ?instanceOfStatement pq:P582 ?end }  # no longer a country
   ?item p:P463 ?memberOfStatement .
   ?memberOfStatement ps:P463 wd:Q1065 .


### PR DESCRIPTION
Until now we'd assumed that all countries were direct instances of
country, but some (e.g. North Macedonia) are instances of subclasses of
country.

No tests as this is just a query change.